### PR TITLE
Add Mac Roman Encoding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,7 @@ impl<'src, T: Resolve> FontCache<'src, T> {
                 BaseEncoding::StandardEncoding => &pdf_encoding::STANDARD,
                 BaseEncoding::SymbolEncoding => &pdf_encoding::SYMBOL,
                 BaseEncoding::WinAnsiEncoding => &pdf_encoding::WINANSI,
+                BaseEncoding::MacRomanEncoding => &pdf_encoding::MACROMAN,
                 ref e => {
                     warn!("unsupported pdf encoding {:?}", e);
                     return;


### PR DESCRIPTION
An alternative to this implementation could be to move this functionality into the pdf_encoding crate with an optional dependency on the pdf create that provides a `std::convert::TryInto` or `std::convert::TryFrom` implementation.

Let me know if you'd prefer it done that way.