### PR TITLE
use new utf16be decode functions from pdf::fonts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 
 [dependencies]
 pdf = { git = "https://github.com/pdf-rs/pdf", features = [ "euclid" ] }
-pdf_encoding = "*"
+pdf_encoding = { git = "https://github.com/pdf-rs/encoding" }
 euclid = "0.22.6"
 log = "*"


### PR DESCRIPTION
- more reliably decode Cmap german pdf, demo pdf can be found [here](https://www.wir.ch/fileadmin/user_upload/Dokumente/Informationen/zinsen-konditionen-bank-wir-de.pdf) this produces almost empty strings in the previous version of pdf2text
- should do one less allocation per utf16 string
- Cmap decoding broken anyways, uses slice::windows??
- this only works with my PR of pdf-rs/pdf#119
- this likely fixes the "not all strings are present" part of pdf-rs/pdf#102