### PR TITLE
Don't add newline if translation Y is >= 0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,7 +276,7 @@ pub fn page_text(page: &Page, resolve: &impl Resolve) -> Result<String, PdfError
                 out.push('\n');
             }
             Op::MoveTextPosition { translation } => {
-                if translation.y.abs() < f32::EPSILON {
+                if translation.y < 0.0 {
                     out.push('\n');
                 }
             }


### PR DESCRIPTION
Hi! I think new line should be pushed only if translation Y is lower than 0. Otherwise it breaks a line in the middle of a word in some documents.
Example pdf: https://www.orimi.com/pdf-test.pdf (archived on github for future readers: [pdf-test.pdf](https://github.com/pdf-rs/pdf_tools/files/10010509/pdf-test.pdf))
![image](https://user-images.githubusercontent.com/9150636/201869654-3f56e007-e955-4d2e-a237-7ec48aba29ed.png)

Without my patch it returns a string like this:
```
    PDF Test File 
     
    Congratulations, your comput
    er is equipped with a PDF (Portable Document Format) reader!  You should be able to view any of
     the PDF documents and forms available on our site.  PDF forms are indicated by these icons: 
      or  
    .   
     
    Yukon Department of Education 
    Box 2703 
    Whitehorse,Yukon 
    Canada 
    Y1A 2C6 
     
    Please visit our website at:  
    http://www.education.gov.yk.ca/
```
Focus on the second line: ``Congratulations, your comput[New Line]er``. It shouldn't be like this.
With my patch:
```
    PDF Test File 
     
    Congratulations, your computer is equipped with a PDF (Portable Document Format) 
    reader!  You should be able to view any of the PDF documents and forms available on 
    our site.  PDF forms are indicated by these icons: 
      or  
    .   
     
    Yukon Department of Education 
    Box 2703 
    Whitehorse,Yukon 
    Canada 
    Y1A 2C6 
     
    Please visit our website at:  
    http://www.education.gov.yk.ca/

```
It doesn't break line in the middle of a word!
I'm not completely sure if this is 100% right. I don't know why ``f32::EPSILON`` was here, so correct me if I'm wrong, but I tested it with sample documents which I found in google and it seems to be less broken with my patch.
